### PR TITLE
System D service

### DIFF
--- a/jena/JosekiExtensions/build.xml
+++ b/jena/JosekiExtensions/build.xml
@@ -174,7 +174,7 @@
 			</then>
 			<else>
 				<copy todir="${deployableSvrDir}">
-					<fileset dir="${configDir}/unix" includes="*.sh"/>
+					<fileset dir="${configDir}/unix" includes="*.sh,*.service"/>
 				</copy>
 				<chmod file="${deployableSvrDir}/*.sh" perm="ugo+rx" verbose="true"/>
 			</else>

--- a/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
+++ b/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
@@ -30,8 +30,13 @@ if [ -z "$username" -o -z "$directory" ] ; then
 	exit 1
 fi
 
+if [ -z "$JAVA_HOME" ] ; then
+	JAVA_HOME=$(dirname $(which java))
+fi
+
 cp -f parliament.service /etc/systemd/system/parliament.service
 sed -i -e "s/USERNAME/$username/g" /etc/systemd/system/parliament.service
 sed -i -e "s|DIRECTORY|$directory|g" /etc/systemd/system/parliament.service
+sed -i -e "s|JAVAHOME|$JAVA_HOME|g" /etc/systemd/system/parliament.service
 systemctl enable parliament
 systemctl start parliament

--- a/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
+++ b/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 usage="$(basename "$0") --username USERNAME --directory DIRECTORY --javahome JAVAHOME -- installs Parliament as a System D service
 
 where:

--- a/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
+++ b/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
@@ -9,28 +9,29 @@ directory=
 
 while [ "$1" != "" ]; do
 	case $1 in
-		-u | --username )	shift
-							username=$1
-							;;
-		-d | --d )			shift
-							directory=$1
-							;;
-		-h | --help )		echo "$usage"> &2
-							exit
-							;;
-		* )					echo "$usage" >&2
-							exit 1
-							;;
+		-u|--username)	shift
+						username=$1
+						;;
+		-d|--d)			shift
+						directory=$1
+						;;
+		-h|--help)		echo "$usage" >&2
+						exit
+						;;
+		*)				echo "$usage" >&2
+						exit 1
+						;;
 	esac
 	shift
 done
 
-if [ username == "" -o directory == "" ] ; then
+if [ -z "$username" -o -z "$directory" ] ; then
 	echo "$usage" >&2
 	exit 1
 fi
 
-sed -i -e "s/USERNAME/$username/g" $directory/parliament.service
-cp parliament.service /etc/systemd/system/parliament.service
+cp -f parliament.service /etc/systemd/system/parliament.service
+sed -i -e "s/USERNAME/$username/g" /etc/systemd/system/parliament.service
+sed -i -e "s|DIRECTORY|$directory|g" /etc/systemd/system/parliament.service
 systemctl enable parliament
 systemctl start parliament

--- a/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
+++ b/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
@@ -1,11 +1,13 @@
-usage="$(basename "$0") --username USERNAME --directory DIRECTORY -- installs Parliament as a System D service
+usage="$(basename "$0") --username USERNAME --directory DIRECTORY --javahome JAVAHOME -- installs Parliament as a System D service
 
 where:
 	--username		the account under which to run Parliament
 	--directory		the absolute path to Parliament's installation
+	--javahome		the absolute path to the desired Java installation
 "
 username=
 directory=
+javahome=
 
 while [ "$1" != "" ]; do
 	case $1 in
@@ -14,6 +16,9 @@ while [ "$1" != "" ]; do
 						;;
 		-d|--d)			shift
 						directory=$1
+						;;
+		-j|--javahome)	shift
+						javahome=$1
 						;;
 		-h|--help)		echo "$usage" >&2
 						exit
@@ -25,19 +30,14 @@ while [ "$1" != "" ]; do
 	shift
 done
 
-if [ -z "$username" -o -z "$directory" ] ; then
+if [ -z "$username" -o -z "$directory" -o -z "$javahome" ] ; then
 	echo "$usage" >&2
 	exit 1
-fi
-
-if [ -z "$JAVA_HOME" ] ; then
-	echo "You must set and export the JAVA_HOME environment variable."
-	exit 2
 fi
 
 cp -f parliament.service /etc/systemd/system/parliament.service
 sed -i -e "s/USERNAME/$username/g" /etc/systemd/system/parliament.service
 sed -i -e "s|DIRECTORY|$directory|g" /etc/systemd/system/parliament.service
-sed -i -e "s|JAVAHOME|$JAVA_HOME|g" /etc/systemd/system/parliament.service
-systemctl enable parliament
+sed -i -e "s|JAVAHOME|$javahome|g" /etc/systemd/system/parliament.service
 systemctl start parliament
+systemctl enable parliament

--- a/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
+++ b/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
@@ -1,0 +1,36 @@
+usage="$(basename "$0") --username USERNAME --directory DIRECTORY -- installs Parliament as a System D service
+
+where:
+	--username		the account under which to run Parliament
+	--directory		the absolute path to Parliament's installation
+"
+username=
+directory=
+
+while [ "$1" != "" ]; do
+	case $1 in
+		-u | --username )	shift
+							username=$1
+							;;
+		-d | --d )			shift
+							directory=$1
+							;;
+		-h | --help )		echo "$usage"> &2
+							exit
+							;;
+		* )					echo "$usage" >&2
+							exit 1
+							;;
+	esac
+	shift
+done
+
+if [ username == "" -o directory == "" ] ; then
+	echo "$usage" >&2
+	exit 1
+fi
+
+sed -i -e "s/USERNAME/$username/g" $directory/parliament.service
+cp parliament.service /etc/systemd/system/parliament.service
+systemctl enable parliament
+systemctl start parliament

--- a/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
+++ b/jena/JosekiExtensions/resources/conf/unix/InstallService.sh
@@ -31,7 +31,8 @@ if [ -z "$username" -o -z "$directory" ] ; then
 fi
 
 if [ -z "$JAVA_HOME" ] ; then
-	JAVA_HOME=$(dirname $(which java))
+	echo "You must set and export the JAVA_HOME environment variable."
+	exit 2
 fi
 
 cp -f parliament.service /etc/systemd/system/parliament.service

--- a/jena/JosekiExtensions/resources/conf/unix/parliament.service
+++ b/jena/JosekiExtensions/resources/conf/unix/parliament.service
@@ -8,6 +8,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=USERNAME
+Environment=JAVA_HOME=JAVAHOME
 ExecStart=DIRECTORY/StartParliamentDaemon.sh start
 ExecStop=DIRECTORY/StartParliamentDaemon.sh stop
 

--- a/jena/JosekiExtensions/resources/conf/unix/parliament.service
+++ b/jena/JosekiExtensions/resources/conf/unix/parliament.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Parliament service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=USERNAME
+ExecStart=DIRECTORY/StartParliamentDaemon.sh
+# Is there a special command or interaction necessary to turn off the Parliament daemon?
+# ExecStop=???
+
+[Install]
+WantedBy=multi-user.target

--- a/jena/JosekiExtensions/resources/conf/unix/parliament.service
+++ b/jena/JosekiExtensions/resources/conf/unix/parliament.service
@@ -8,9 +8,8 @@ Type=simple
 Restart=always
 RestartSec=1
 User=USERNAME
-ExecStart=DIRECTORY/StartParliamentDaemon.sh
-# Is there a special command or interaction necessary to turn off the Parliament daemon?
-# ExecStop=???
+ExecStart=DIRECTORY/StartParliamentDaemon.sh start
+ExecStop=DIRECTORY/StartParliamentDaemon.sh stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This branch adds built-in capability to install Parliament in a System D-based OS as a service.  If one downloads Parliament, then runs `sudo ./InstallService.sh -u {USERNAME} -d {PARLIAMENT HOME DIRECTORY} -j {JAVA_HOME}`, this script will copy a service configuration using those arguments, launch the service, then configure this service to start when the OS boots.