### PR TITLE
Query timeout

### DIFF
--- a/Parliament/KbCore/Config.cpp
+++ b/Parliament/KbCore/Config.cpp
@@ -185,7 +185,9 @@ pmnt::Config::Config() :
 	m_inferRdfsClass(false),
 	m_inferOwlClass(false),
 	m_inferRdfsResource(false),
-	m_inferOwlThing(false)
+	m_inferOwlThing(false),
+  m_timeoutDuration(5),
+  m_timeoutUnit("MINUTES")
 {
 }
 
@@ -472,6 +474,14 @@ void pmnt::Config::parseKeyValuePair(const string& key,
 	else if (ba::iequals(key, "inferOwlThing"))
 	{
 		cp.m_inferOwlThing = parseBool(value, lineNum);
+	}
+  else if (ba::iequals(key, "TimeoutDuration"))
+	{
+		cp.m_timeoutDuration = parseUnsigned(value, lineNum);
+	}
+	else if (ba::iequals(key, "TimeoutUnit"))
+	{
+		cp.m_timeoutUnit = value;
 	}
 	else
 	{

--- a/Parliament/KbCore/Config.cpp
+++ b/Parliament/KbCore/Config.cpp
@@ -481,6 +481,14 @@ void pmnt::Config::parseKeyValuePair(const string& key,
 	}
 	else if (ba::iequals(key, "TimeoutUnit"))
 	{
+		if (!validateTimeUnit(value)) {
+			throw Exception(
+				format("Illegal configuration file syntax: invalid '%1%' value '%2%' on line %3%")
+					% key
+					% value
+					% lineNum
+			);
+		}
 		cp.m_timeoutUnit = value;
 	}
 	else
@@ -582,4 +590,15 @@ const pmnt::Config& pmnt::Config::ensureKbDirExists() const
 			% m_kbDirectoryPath.generic_string());
 	}
 	return *this;
+}
+
+bool pmnt::Config::validateTimeUnit(const string& s) {
+	return ba::equals(s, "MILLISECONDS") || ba::equals(s, "SECONDS") || ba::equals(s, "MINUTES");
+}
+
+void pmnt::Config::timeoutUnit(const string& newValue) {
+	if (!validateTimeUnit(newValue)) {
+		throw Exception(format("Invalid time unit: '%1%'") % newValue);
+	}
+	m_timeoutUnit = newValue;
 }

--- a/Parliament/KbCore/Config.cpp
+++ b/Parliament/KbCore/Config.cpp
@@ -186,8 +186,8 @@ pmnt::Config::Config() :
 	m_inferOwlClass(false),
 	m_inferRdfsResource(false),
 	m_inferOwlThing(false),
-  m_timeoutDuration(5),
-  m_timeoutUnit("MINUTES")
+	m_timeoutDuration(5),
+	m_timeoutUnit("MINUTES")
 {
 }
 
@@ -475,7 +475,7 @@ void pmnt::Config::parseKeyValuePair(const string& key,
 	{
 		cp.m_inferOwlThing = parseBool(value, lineNum);
 	}
-  else if (ba::iequals(key, "TimeoutDuration"))
+	else if (ba::iequals(key, "TimeoutDuration"))
 	{
 		cp.m_timeoutDuration = parseUnsigned(value, lineNum);
 	}

--- a/Parliament/KbCore/ConfigJNI.cpp
+++ b/Parliament/KbCore/ConfigJNI.cpp
@@ -80,8 +80,8 @@ static void assignCppConfigToJavaConfig(JNIEnv* pEnv, jobject obj, const Config&
 	JNIHelper::setBooleanFld(pEnv, obj,	"m_inferRdfsResource",				config.inferRdfsResource());
 	JNIHelper::setBooleanFld(pEnv, obj,	"m_inferOwlThing",					config.inferOwlThing());
 
-  JNIHelper::setLongFld(pEnv, obj, "m_timeoutDuration", config.timeoutDuration());
-  JNIHelper::setStringFld(pEnv, obj, "m_timeoutUnit", config.timeoutUnit());
+	JNIHelper::setLongFld(pEnv, obj, "m_timeoutDuration", config.timeoutDuration());
+	JNIHelper::setStringFld(pEnv, obj, "m_timeoutUnit", config.timeoutUnit());
 }
 
 JNIEXPORT void JNICALL Java_com_bbn_parliament_jni_Config_init(

--- a/Parliament/KbCore/ConfigJNI.cpp
+++ b/Parliament/KbCore/ConfigJNI.cpp
@@ -79,6 +79,9 @@ static void assignCppConfigToJavaConfig(JNIEnv* pEnv, jobject obj, const Config&
 	JNIHelper::setBooleanFld(pEnv, obj,	"m_inferOwlClass",					config.inferOwlClass());
 	JNIHelper::setBooleanFld(pEnv, obj,	"m_inferRdfsResource",				config.inferRdfsResource());
 	JNIHelper::setBooleanFld(pEnv, obj,	"m_inferOwlThing",					config.inferOwlThing());
+
+  JNIHelper::setLongFld(pEnv, obj, "m_timeoutDuration", config.timeoutDuration());
+  JNIHelper::setStringFld(pEnv, obj, "m_timeoutUnit", config.timeoutUnit());
 }
 
 JNIEXPORT void JNICALL Java_com_bbn_parliament_jni_Config_init(

--- a/Parliament/KbCore/KbInstanceJNI.cpp
+++ b/Parliament/KbCore/KbInstanceJNI.cpp
@@ -138,6 +138,9 @@ static void assignJavaConfigToCppConfig(Config& config, JNIEnv* pEnv, jobject ob
 	config.inferOwlClass(					JNIHelper::getBooleanFld(pEnv, obj,	"m_inferOwlClass"));
 	config.inferRdfsResource(			JNIHelper::getBooleanFld(pEnv, obj,	"m_inferRdfsResource"));
 	config.inferOwlThing(					JNIHelper::getBooleanFld(pEnv, obj,	"m_inferOwlThing"));
+
+  config.timeoutDuration(JNIHelper::getSizeTFld(pEnv, obj, "m_timeoutDuration"));
+  config.timeoutUnit(JNIHelper::getStringFld(pEnv, obj, "m_timeoutUnit"));
 }
 
 JNIEXPORT void JNICALL Java_com_bbn_parliament_jni_KbInstance_init(

--- a/Parliament/KbCore/KbInstanceJNI.cpp
+++ b/Parliament/KbCore/KbInstanceJNI.cpp
@@ -139,8 +139,8 @@ static void assignJavaConfigToCppConfig(Config& config, JNIEnv* pEnv, jobject ob
 	config.inferRdfsResource(			JNIHelper::getBooleanFld(pEnv, obj,	"m_inferRdfsResource"));
 	config.inferOwlThing(					JNIHelper::getBooleanFld(pEnv, obj,	"m_inferOwlThing"));
 
-  config.timeoutDuration(JNIHelper::getSizeTFld(pEnv, obj, "m_timeoutDuration"));
-  config.timeoutUnit(JNIHelper::getStringFld(pEnv, obj, "m_timeoutUnit"));
+	config.timeoutDuration(JNIHelper::getSizeTFld(pEnv, obj, "m_timeoutDuration"));
+	config.timeoutUnit(JNIHelper::getStringFld(pEnv, obj, "m_timeoutUnit"));
 }
 
 JNIEXPORT void JNICALL Java_com_bbn_parliament_jni_KbInstance_init(

--- a/Parliament/KbCore/ParliamentConfig.txt
+++ b/Parliament/KbCore/ParliamentConfig.txt
@@ -122,3 +122,9 @@ InvFunctionalPropRule  = off
 # Sets up the following rule:
 # * "P is a transitive property" ^ "P(X, Y)" ^ "P(Y, Z)" ==> "P(X, Z)"
 TransitivePropRule     = on
+
+
+
+#####   Query execution configuration   #####
+TimeoutDuration        = 5
+TimeoutUnit            = MINUTES

--- a/Parliament/KbCore/parliament/Config.h
+++ b/Parliament/KbCore/parliament/Config.h
@@ -311,9 +311,8 @@ public:
 
 	// Unit for timeout duration
 	::std::string timeoutUnit() const
-		{ return { m_timeoutUnit }; }
-	void timeoutUnit(::std::string newValue)
-		{ m_timeoutUnit = { newValue }; }
+		{ return m_timeoutUnit; }
+	void timeoutUnit(const ::std::string& newValue);
 
 	void disableAllRules();
 
@@ -344,6 +343,7 @@ private:
 	static size_t parseUnsigned(const ::std::string& s, uint32 lineNum);
 	static double parseDouble(const ::std::string& s, uint32 lineNum);
 	static bool parseBool(const ::std::string& s, uint32 lineNum);
+	static bool validateTimeUnit(const ::std::string& s);
 
 	bool								m_logToConsole;
 	bool								m_logConsoleAsynchronous;

--- a/Parliament/KbCore/parliament/Config.h
+++ b/Parliament/KbCore/parliament/Config.h
@@ -303,17 +303,17 @@ public:
 	void inferOwlThing(bool newValue)
 		{ m_inferOwlThing = newValue; }
 
-  // How long to allow a query to run before aborting it.
-  size_t timeoutDuration() const
-    { return m_timeoutDuration; }
-  void timeoutDuration(size_t newValue)
-    { m_timeoutDuration = newValue; }
+	// How long to allow a query to run before aborting it.
+	size_t timeoutDuration() const
+		{ return m_timeoutDuration; }
+	void timeoutDuration(size_t newValue)
+		{ m_timeoutDuration = newValue; }
 
-  // Unit for timeout duration
-  ::std::string timeoutUnit() const
-    { return { m_timeoutUnit }; }
-  void timeoutUnit(::std::string newValue)
-    { m_timeoutUnit = { newValue }; }
+	// Unit for timeout duration
+	::std::string timeoutUnit() const
+		{ return { m_timeoutUnit }; }
+	void timeoutUnit(::std::string newValue)
+		{ m_timeoutUnit = { newValue }; }
 
 	void disableAllRules();
 
@@ -396,8 +396,8 @@ private:
 	bool								m_inferRdfsResource;
 	bool								m_inferOwlThing;
 
-  size_t                m_timeoutDuration;
-  ::std::string       m_timeoutUnit;
+	size_t								m_timeoutDuration;
+	::std::string						m_timeoutUnit;
 };
 
 PARLIAMENT_NAMESPACE_END

--- a/Parliament/KbCore/parliament/Config.h
+++ b/Parliament/KbCore/parliament/Config.h
@@ -303,6 +303,18 @@ public:
 	void inferOwlThing(bool newValue)
 		{ m_inferOwlThing = newValue; }
 
+  // How long to allow a query to run before aborting it.
+  size_t timeoutDuration() const
+    { return m_timeoutDuration; }
+  void timeoutDuration(size_t newValue)
+    { m_timeoutDuration = newValue; }
+
+  // Unit for timeout duration
+  ::std::string timeoutUnit() const
+    { return { m_timeoutUnit }; }
+  void timeoutUnit(::std::string newValue)
+    { m_timeoutUnit = { newValue }; }
+
 	void disableAllRules();
 
 	const Config& ensureKbDirExists() const;
@@ -383,6 +395,9 @@ private:
 	bool								m_inferOwlClass;
 	bool								m_inferRdfsResource;
 	bool								m_inferOwlThing;
+
+  size_t                m_timeoutDuration;
+  ::std::string       m_timeoutUnit;
 };
 
 PARLIAMENT_NAMESPACE_END

--- a/Parliament/Test/ConfigTest.cpp
+++ b/Parliament/Test/ConfigTest.cpp
@@ -303,6 +303,9 @@ BOOST_AUTO_TEST_CASE(testConfigDefaultCtor)
 	BOOST_CHECK_EQUAL(false, c.inferOwlClass());
 	BOOST_CHECK_EQUAL(false, c.inferRdfsResource());
 	BOOST_CHECK_EQUAL(false, c.inferOwlThing());
+
+  BOOST_CHECK_EQUAL(5, c.timeoutDuration());
+  BOOST_CHECK_EQUAL(string("MINUTES"), c.timeoutUnit());
 }
 
 // =========================================================================
@@ -375,6 +378,9 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		s << "inferOwlClass        = no" << endl;
 		s << "inferRdfsResource    = yes" << endl;
 		s << "inferOwlThing        = no" << endl;
+    s << endl;
+    s << "timeoutLength = 200" << endl;
+    s << "timeoutUnit = MILLISECONDS" << endl;
 		s.close();
 
 		BOOST_REQUIRE_NO_THROW(c = Config::readFromFile());
@@ -432,6 +438,9 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		BOOST_CHECK_EQUAL(false, c.inferOwlClass());
 		BOOST_CHECK_EQUAL(true, c.inferRdfsResource());
 		BOOST_CHECK_EQUAL(false, c.inferOwlThing());
+
+    BOOST_CHECK_EQUAL(200, c.timeoutDuration());
+    BOOST_CHECK_EQUAL(string("MILLISECONDS"), c.timeoutUnit());
 	}
 
 	{
@@ -491,6 +500,9 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		s << "inferOwlClass        = yes" << endl;
 		s << "inferRdfsResource    = yes" << endl;
 		s << "inferOwlThing        = yes" << endl;
+    s << endl;
+    s << "timeoutLength = 200" << endl;
+    s << "timeoutUnit = MILLISECONDS" << endl;
 		s.close();
 
 		BOOST_CHECK_THROW(c = Config::readFromFile(), Exception);
@@ -550,6 +562,9 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 	BOOST_CHECK_EQUAL(defaults.inferOwlClass(), c.inferOwlClass());
 	BOOST_CHECK_EQUAL(defaults.inferRdfsResource(), c.inferRdfsResource());
 	BOOST_CHECK_EQUAL(defaults.inferOwlThing(), c.inferOwlThing());
+
+  BOOST_CHECK_EQUAL(defaults.timeoutDuration(), c.timeoutDuration());
+  BOOST_CHECK_EQUAL(defaults.timeoutUnit(), c.timeoutUnit());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Parliament/Test/ConfigTest.cpp
+++ b/Parliament/Test/ConfigTest.cpp
@@ -304,8 +304,8 @@ BOOST_AUTO_TEST_CASE(testConfigDefaultCtor)
 	BOOST_CHECK_EQUAL(false, c.inferRdfsResource());
 	BOOST_CHECK_EQUAL(false, c.inferOwlThing());
 
-  BOOST_CHECK_EQUAL(5, c.timeoutDuration());
-  BOOST_CHECK_EQUAL(string("MINUTES"), c.timeoutUnit());
+	BOOST_CHECK_EQUAL(5, c.timeoutDuration());
+	BOOST_CHECK_EQUAL(string("MINUTES"), c.timeoutUnit());
 }
 
 // =========================================================================
@@ -378,9 +378,9 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		s << "inferOwlClass        = no" << endl;
 		s << "inferRdfsResource    = yes" << endl;
 		s << "inferOwlThing        = no" << endl;
-    s << endl;
-    s << "timeoutLength = 200" << endl;
-    s << "timeoutUnit = MILLISECONDS" << endl;
+		s << endl;
+		s << "TimeoutDuration = 200" << endl;
+		s << "TimeoutUnit = MILLISECONDS" << endl;
 		s.close();
 
 		BOOST_REQUIRE_NO_THROW(c = Config::readFromFile());
@@ -439,8 +439,8 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		BOOST_CHECK_EQUAL(true, c.inferRdfsResource());
 		BOOST_CHECK_EQUAL(false, c.inferOwlThing());
 
-    BOOST_CHECK_EQUAL(200, c.timeoutDuration());
-    BOOST_CHECK_EQUAL(string("MILLISECONDS"), c.timeoutUnit());
+		BOOST_CHECK_EQUAL(200, c.timeoutDuration());
+		BOOST_CHECK_EQUAL(string("MILLISECONDS"), c.timeoutUnit());
 	}
 
 	{
@@ -500,9 +500,9 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		s << "inferOwlClass        = yes" << endl;
 		s << "inferRdfsResource    = yes" << endl;
 		s << "inferOwlThing        = yes" << endl;
-    s << endl;
-    s << "timeoutLength = 200" << endl;
-    s << "timeoutUnit = MILLISECONDS" << endl;
+		s << endl;
+		s << "TimeoutDuration = 200" << endl;
+		s << "TimeoutUnit = MILLISECONDS" << endl;
 		s.close();
 
 		BOOST_CHECK_THROW(c = Config::readFromFile(), Exception);
@@ -563,8 +563,8 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 	BOOST_CHECK_EQUAL(defaults.inferRdfsResource(), c.inferRdfsResource());
 	BOOST_CHECK_EQUAL(defaults.inferOwlThing(), c.inferOwlThing());
 
-  BOOST_CHECK_EQUAL(defaults.timeoutDuration(), c.timeoutDuration());
-  BOOST_CHECK_EQUAL(defaults.timeoutUnit(), c.timeoutUnit());
+	BOOST_CHECK_EQUAL(defaults.timeoutDuration(), c.timeoutDuration());
+	BOOST_CHECK_EQUAL(defaults.timeoutUnit(), c.timeoutUnit());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Parliament/java/com/bbn/parliament/jni/Config.java
+++ b/Parliament/java/com/bbn/parliament/jni/Config.java
@@ -223,6 +223,12 @@ public class Config
 	/** Whether to infer owl:Thing based on subclass statements */
 	public boolean m_inferOwlThing;
 
+	/** How long a query should be allowed to run before being aborted */
+	public Long m_timeoutDuration;
+
+	/** The units for m_timeoutDuration */
+	public String m_timeoutUnit;
+
 	public void disableAllRules()
 	{
 		m_enableSWRLRuleEngine = false;

--- a/Parliament/java/com/bbn/parliament/jni/Config.java
+++ b/Parliament/java/com/bbn/parliament/jni/Config.java
@@ -224,7 +224,7 @@ public class Config
 	public boolean m_inferOwlThing;
 
 	/** How long a query should be allowed to run before being aborted */
-	public Long m_timeoutDuration;
+	public long m_timeoutDuration;
 
 	/** The units for m_timeoutDuration */
 	public String m_timeoutUnit;

--- a/jena/JosekiExtensions/src/com/bbn/parliament/jena/joseki/bridge/tracker/TrackableQuery.java
+++ b/jena/JosekiExtensions/src/com/bbn/parliament/jena/joseki/bridge/tracker/TrackableQuery.java
@@ -2,11 +2,13 @@ package com.bbn.parliament.jena.joseki.bridge.tracker;
 
 import java.beans.ConstructorProperties;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.bbn.parliament.jena.joseki.graph.ModelManager;
+import com.bbn.parliament.jni.Config;
 import com.hp.hpl.jena.query.Query;
 import com.hp.hpl.jena.query.QueryExecution;
 import com.hp.hpl.jena.query.QueryExecutionFactory;
@@ -25,6 +27,15 @@ import com.hp.hpl.jena.sparql.engine.binding.Binding;
  */
 public class TrackableQuery extends Trackable {
 	private static Logger _log = LoggerFactory.getLogger(TrackableQuery.class);
+	
+	private static final Long TIMEOUT_DURATION;
+	private static final TimeUnit TIMEOUT_UNIT;
+
+	static {
+		Config config = Config.readFromFile();
+		TIMEOUT_DURATION = config.m_timeoutDuration;
+		TIMEOUT_UNIT = TimeUnit.valueOf(config.m_timeoutUnit);
+	}
 
 	private final Query _query;
 	// private final AtomicBoolean _cancelled;
@@ -71,6 +82,7 @@ public class TrackableQuery extends Trackable {
 		} else {
 			_qExec = QueryExecutionFactory.create(_query);
 		}
+		_qExec.setTimeout(TIMEOUT_DURATION, TIMEOUT_UNIT);
 
 		// add a cancel flag to the query execution context. The context is a
 		// copy of the ARQ global context (The constructor for


### PR DESCRIPTION
This commit adds two configuration parameters to ParliamentConfig.txt: `TimeoutDuration` and `TimeoutUnit`.  The first is an unsigned number.  The second is a value from [Java's TimeUnit](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html) .  These two values are used in JosekiExtension's `TrackableQuery` class to configure Parliament queries to expire.

The current default is five minutes.