### PR TITLE
Fixed PersistentTemporalIndex and the TemporalExtent classes, plus additional broken test fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -167,8 +167,8 @@
 		<ant dir="${basedir}/jena/NumericIndex" target="runTests" inheritAll="false"/>
 		<!--
 		<ant dir="${basedir}/jena/SpatialIndexProcessor" target="runTests" inheritAll="false"/>
-		<ant dir="${basedir}/jena/TemporalIndexProcessor" target="runTests" inheritAll="false"/>
 		-->
+		<ant dir="${basedir}/jena/TemporalIndexProcessor" target="runTests" inheritAll="false"/>
 		<!--
 		<ant dir="${basedir}/Sesame/CSameAsSail" target="runTests" inheritAll="false"/>
 		<ant dir="${basedir}/Sesame/ParliamentSail" target="runTests" inheritAll="false"/>

--- a/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalExtent.java
+++ b/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalExtent.java
@@ -10,7 +10,9 @@ package com.bbn.parliament.jena.graph.index.temporal.extent;
  * index.
  *
  *  @author dkolas */
-public abstract class TemporalExtent {
-	public abstract TemporalInstant getStart();
-	public abstract TemporalInstant getEnd();
+public interface TemporalExtent {
+	TemporalInstant getStart();
+	TemporalInstant getEnd();
+
+	boolean sameAs(TemporalExtent other);
 }

--- a/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalInstant.java
+++ b/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalInstant.java
@@ -6,6 +6,7 @@
 package com.bbn.parliament.jena.graph.index.temporal.extent;
 
 import java.util.Calendar;
+import java.util.Objects;
 
 import com.hp.hpl.jena.datatypes.xsd.XSDDateTime;
 import com.hp.hpl.jena.graph.Node;
@@ -20,7 +21,7 @@ import com.hp.hpl.jena.graph.Node;
  * @author dkolas
  * */
 
-public class TemporalInstant extends TemporalExtent implements Comparable<TemporalInstant> {
+public class TemporalInstant implements TemporalExtent, Comparable<TemporalInstant> {
 	protected long instant;
 	protected TemporalInterval parentInterval;
 	protected boolean isStart = false;
@@ -72,25 +73,29 @@ public class TemporalInstant extends TemporalExtent implements Comparable<Tempor
 	 * Performs a total-ordering comparison. This means that 2 TemporalInstant objects that
 	 * represent the same time, but for different intervals are not actually equal.
 	 *
-	 * @param o TemporalInstant object to compare with
+	 * @param that TemporalInstant object to compare with
 	 * @return -1 if the given argument is greater than this object. 1 if the argument is
 	 *         smaller. 0 if they are equal.
 	 */
 	@Override
-	public int compareTo(TemporalInstant o) {
-		if (instant < o.instant) {
-			return -1;
-		} else if (instant > o.instant) {
-			return 1;
-		} else { // they have equivalent timestamps
-			if (isStart && !o.isStart) { // this object's interval occurs after
-				return 1;
-			} else if (isEnd && o.isStart) { // this object's interval occurs before
-				return -1;
-			} else {
-				return hashCode() - o.hashCode();
+	public int compareTo(TemporalInstant that) {
+		int comparison = Long.compare(this.instant, that.instant);
+		if (comparison == 0) {
+			comparison = (this.isStart ? -1 : 0) + (that.isStart ? 1 : 0);
+			if (comparison == 0) {
+				comparison = (this.isEnd ? 1 : 0) + (that.isEnd ? -1 : 0);
+				if (comparison == 0) {
+					comparison = (
+						(this.parentInterval == null ? -1 : 0) +
+						(that.parentInterval == null ? 1 : 0)
+					);
+					if (comparison == 0 && this.parentInterval != null) {
+						comparison = this.parentInterval.compareTo(that.parentInterval);
+					}
+				}
 			}
 		}
+		return comparison;
 	}
 
 	@Override
@@ -100,7 +105,7 @@ public class TemporalInstant extends TemporalExtent implements Comparable<Tempor
 			return (instant == ti.instant
 					&& isStart == ti.isStart
 					&& isEnd == ti.isEnd
-					&& parentInterval == ti.parentInterval
+					&& Objects.equals(parentInterval, ti.parentInterval)
 					);
 		}
 		return false;
@@ -108,13 +113,7 @@ public class TemporalInstant extends TemporalExtent implements Comparable<Tempor
 
 	@Override
 	public int hashCode() {
-		int result = Long.valueOf(instant).hashCode();
-		result ^= Boolean.valueOf(isStart).hashCode();
-		result ^= Integer.rotateLeft(Boolean.valueOf(isEnd).hashCode(), 4);
-		if (parentInterval != null) {
-			result ^= parentInterval.hashCode();
-		}
-		return result;
+		return Objects.hash(instant, isStart, isEnd, parentInterval);
 	}
 
 	@Override
@@ -158,8 +157,13 @@ public class TemporalInstant extends TemporalExtent implements Comparable<Tempor
 	 * does not compare the actual nodes that use this instant. Instead, it only compares
 	 * the value of the instant.
 	 */
-	public boolean sameAs(TemporalInstant instant2) {
-		return instant == instant2.instant;
+	@Override
+	public boolean sameAs(TemporalExtent other) {
+		return (
+			other != null &&
+			TemporalInstant.class.equals(other.getClass()) &&
+			instant == ((TemporalInstant) other).instant
+		);
 	}
 
 	/**

--- a/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalInstant.java
+++ b/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalInstant.java
@@ -73,6 +73,12 @@ public class TemporalInstant implements TemporalExtent, Comparable<TemporalInsta
 	 * Performs a total-ordering comparison. This means that 2 TemporalInstant objects that
 	 * represent the same time, but for different intervals are not actually equal.
 	 *
+	 * TemporalInstants are ordered as follows:
+	 * 1) TemporalInstants with earlier epochs ("instants") precede those with later epochs.
+	 * 2) TemporalInstants that are not part of a TemporalInterval precede those that are.
+	 * 3) TemporalInstants that are the starts of their TemporalIntervals precede those that end theirs.
+	 * 4) TemporalInstants that are otherwise equivalent break their ties based upon their TemporalIntervals' orderings.
+	 *
 	 * @param that TemporalInstant object to compare with
 	 * @return -1 if the given argument is greater than this object. 1 if the argument is
 	 *         smaller. 0 if they are equal.
@@ -81,17 +87,14 @@ public class TemporalInstant implements TemporalExtent, Comparable<TemporalInsta
 	public int compareTo(TemporalInstant that) {
 		int comparison = Long.compare(this.instant, that.instant);
 		if (comparison == 0) {
-			comparison = (this.isStart ? -1 : 0) + (that.isStart ? 1 : 0);
-			if (comparison == 0) {
-				comparison = (this.isEnd ? 1 : 0) + (that.isEnd ? -1 : 0);
+			comparison = (
+				(this.parentInterval == null ? -1 : 0) +
+				(that.parentInterval == null ? 1 : 0)
+			);
+			if (comparison == 0 && this.parentInterval != null) {
+				comparison = (this.isStart ? -1 : 0) + (that.isStart ? 1 : 0);
 				if (comparison == 0) {
-					comparison = (
-						(this.parentInterval == null ? -1 : 0) +
-						(that.parentInterval == null ? 1 : 0)
-					);
-					if (comparison == 0 && this.parentInterval != null) {
-						comparison = this.parentInterval.compareTo(that.parentInterval);
-					}
+					comparison = this.parentInterval.compareTo(that.parentInterval);
 				}
 			}
 		}
@@ -104,7 +107,6 @@ public class TemporalInstant implements TemporalExtent, Comparable<TemporalInsta
 			TemporalInstant ti = (TemporalInstant) obj;
 			return (instant == ti.instant
 					&& isStart == ti.isStart
-					&& isEnd == ti.isEnd
 					&& Objects.equals(parentInterval, ti.parentInterval)
 					);
 		}
@@ -113,7 +115,7 @@ public class TemporalInstant implements TemporalExtent, Comparable<TemporalInsta
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(instant, isStart, isEnd, parentInterval);
+		return Objects.hash(instant, isStart, parentInterval);
 	}
 
 	@Override

--- a/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalInterval.java
+++ b/jena/TemporalIndexProcessor/src/com/bbn/parliament/jena/graph/index/temporal/extent/TemporalInterval.java
@@ -5,6 +5,8 @@
 // All rights reserved.
 package com.bbn.parliament.jena.graph.index.temporal.extent;
 
+import java.util.Objects;
+
 /**
  * Implementation for an interval in time. The concrete representation for <code>TemporalInterval</code>s
  * is a pair of 64-bit <code>long</code>s wrapped inside {@link TemporalInstant}s. These represent the endpoints of the
@@ -14,7 +16,7 @@ package com.bbn.parliament.jena.graph.index.temporal.extent;
  * @author dkolas
  * @author mhale
  */
-public class TemporalInterval extends TemporalExtent {
+public class TemporalInterval implements TemporalExtent, Comparable<TemporalInterval> {
 
 	private TemporalInstant start;
 	private TemporalInstant end;
@@ -83,9 +85,15 @@ public class TemporalInterval extends TemporalExtent {
 	 * the values of the start and end of the interval. That means that this *is* an
 	 * appropriate implementation of the Allen Time Interval 'equals' function.
 	 */
-	public boolean sameAs(TemporalInterval interval) {
-		return getStart().sameAs(interval.getStart())
-			&& getEnd().sameAs(interval.getEnd());
+	@Override
+	public boolean sameAs(TemporalExtent other) {
+		TemporalInterval that;
+		return (
+			other != null &&
+			TemporalInterval.class.equals(other.getClass()) &&
+			start.sameAs((that = (TemporalInterval) other).start) &&
+			end.sameAs(that.end)
+		);
 	}
 
 	/** Tests whether this interval ends before the given interval begins. */
@@ -173,6 +181,33 @@ public class TemporalInterval extends TemporalExtent {
 	public boolean finishedBy(TemporalInterval interval) {
 		return getEnd().sameAs(interval.getEnd())
 			&& interval.getStart().greaterThan(getStart());
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		boolean areEqual = this == other;
+		if (!areEqual && TemporalInterval.class.equals(other.getClass())) {
+			TemporalInterval that = (TemporalInterval) other;
+			areEqual = this.start.instant == that.start.instant && this.end.instant == that.end.instant;
+		}
+		return areEqual;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(start.instant, end.instant);
+	}
+
+	@Override
+	public int compareTo(TemporalInterval that) {
+		int comparison = -1;
+		if (that != null) {
+			comparison = Long.compare(this.start.instant, that.start.instant);
+			if (comparison == 0) {
+				comparison = Long.compare(this.end.instant, that.end.instant);
+			}
+		}
+		return comparison;
 	}
 
 	@Override

--- a/jena/TemporalIndexProcessor/test/com/bbn/parliament/jena/graph/index/temporal/query/DuplicateEntriesTest.java
+++ b/jena/TemporalIndexProcessor/test/com/bbn/parliament/jena/graph/index/temporal/query/DuplicateEntriesTest.java
@@ -67,18 +67,16 @@ public class DuplicateEntriesTest {
 		testServer.close();
 	}
 
-	@SuppressWarnings("static-method")
 	@BeforeEach
 	public void beforeEach() {
 		testServer.setupIndex();
 	}
 
 	@AfterEach
-	public static void afterEach() {
+	public void afterEach() {
 		testServer.removeIndex();
 	}
 
-	@SuppressWarnings("static-method")
 	@Test
 	public void testDuplicateEntries() throws Exception {
 		try (Reader rdr = new StringReader(TRIPLES)) {

--- a/jena/TemporalIndexProcessor/test/com/bbn/parliament/jena/graph/index/temporal/query/QueryEdgeCaseTest.java
+++ b/jena/TemporalIndexProcessor/test/com/bbn/parliament/jena/graph/index/temporal/query/QueryEdgeCaseTest.java
@@ -11,8 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -56,7 +58,6 @@ public class QueryEdgeCaseTest {
 		testServer.close();
 	}
 
-	@SuppressWarnings("static-method")
 	@BeforeEach
 	public void beforeEach() {
 		testServer.setupIndex();
@@ -64,7 +65,7 @@ public class QueryEdgeCaseTest {
 	}
 
 	@AfterEach
-	public static void afterEach() {
+	public void afterEach() {
 		testServer.removeIndex();
 	}
 
@@ -78,7 +79,6 @@ public class QueryEdgeCaseTest {
 		addThingWithTime(testServer.getModel(), "2006-02-16T00:00:01Z");
 	}
 
-	@SuppressWarnings("static-method")
 	@Test
 	public void testDuplicateEntries() {
 		String query = TemporalTestServer.COMMON_PREFIXES
@@ -95,7 +95,6 @@ public class QueryEdgeCaseTest {
 		}
 	}
 
-	@SuppressWarnings("static-method")
 	@Test
 	/** Tests the query processor's ability to filter through irrelevant triples with similar subjects */
 	public void testIndexFilter() {
@@ -115,7 +114,6 @@ public class QueryEdgeCaseTest {
 		}
 	}
 
-	@SuppressWarnings("static-method")
 	@Test
 	/** Tests the query processor's ability to filter through irrelevant triples with similar subjects */
 	public void PartialIndexQueryTest() {
@@ -136,7 +134,6 @@ public class QueryEdgeCaseTest {
 		}
 	}
 
-	@SuppressWarnings("static-method")
 	@Test
 	public void testBlankNodes() {
 		String query = TemporalTestServer.COMMON_PREFIXES
@@ -153,7 +150,6 @@ public class QueryEdgeCaseTest {
 		}
 	}
 
-	@SuppressWarnings("static-method")
 	@Test
 	public void testUnboundedOperands() {
 		String query = TemporalTestServer.COMMON_PREFIXES
@@ -181,7 +177,11 @@ public class QueryEdgeCaseTest {
 	}
 
 	private static void checkResults(ResultSet rs, String... results) {
-		List<String> values = Arrays.asList(results);
+		Set<String> values = new HashSet<>();
+		for (String result : results) {
+			values.add(result);
+		}
+
 		int count = 0;
 		try {
 			if (results.length > 0) {


### PR DESCRIPTION
The most extensive changes are to `TemporalExtent`, `TemporalInstant`, and `TemporalInterval`.  Ian and I found some problems with their previous implementations and concluded that it may take extensive investigation to figure out the impacts that changing the odd design choices might have.  This contains what I hope is the minimum number of necessary changes to fix the existing problems with temporal indices.
The reason that `TemporalInterval` implements the `equals`/`hashCode` contract is because there are unit tests that add instances to collections, then compare instances instantiated by queries against those values.