### PR TITLE
Update to Boost version 1.69.0

### DIFF
--- a/Parliament/AdminClient/Jamfile
+++ b/Parliament/AdminClient/Jamfile
@@ -28,6 +28,7 @@ exe ParliamentAdmin
 		/site-config//BoostSystem
 	:	<include>.
 		<visibility>hidden
+		<threading>multi
 		<os>NT:<source>Version.rc
 	:	# default build
 	:	# usage requirements

--- a/Parliament/AdminClient/Jamfile
+++ b/Parliament/AdminClient/Jamfile
@@ -27,6 +27,7 @@ exe ParliamentAdmin
 		/site-config//BoostFileSystem
 		/site-config//BoostSystem
 	:	<include>.
+		<visibility>hidden
 		<os>NT:<source>Version.rc
 	:	# default build
 	:	# usage requirements

--- a/Parliament/JniAssessments/Jamfile
+++ b/Parliament/JniAssessments/Jamfile
@@ -28,6 +28,7 @@ lib JniAssessments
 	:	<include>.
 		<include>../KbCore
 		<define>_REENTRANT
+		<visibility>hidden
 		<threading>multi
 		<implicit-dependency>JniAssessments.h
 	:	# default build

--- a/Parliament/JniAssessments/Jamfile
+++ b/Parliament/JniAssessments/Jamfile
@@ -34,7 +34,7 @@ lib JniAssessments
 	:	# default build
 	:	<include>.
 		<define>_REENTRANT
-		<threading>multi ;
+	;
 
 explicit JniAssessments.h ;
 make JniAssessments.h : [ glob-tree *.java ] : @BuildJar ;

--- a/Parliament/KbCore/Jamfile
+++ b/Parliament/KbCore/Jamfile
@@ -41,7 +41,6 @@ lib Parliament
 		<implicit-dependency>parliament/generated/com_bbn_parliament_jni_ReificationIterator.h
 	:	# default build
 	:	<include>.
-		<threading>multi
 	;
 
 explicit parliament/generated/com_bbn_parliament_jni_Config.h ;

--- a/Parliament/KbCore/Jamfile
+++ b/Parliament/KbCore/Jamfile
@@ -32,6 +32,7 @@ lib Parliament
 		Parliament.jar
 	:	<include>.
 		<define>BUILDING_KBCORE
+		<visibility>hidden
 		<threading>multi
 		<os>NT:<source>Version.rc
 		<implicit-dependency>parliament/generated/com_bbn_parliament_jni_Config.h
@@ -73,5 +74,6 @@ exe Utf8StaticInitGen
 	:	Utf8StaticInitGen.cpp
 	:	<include>.
 		<define>PARLIAMENT_SUPPRESS_AUTOLINK
+		<visibility>hidden
 		<threading>multi
 	;

--- a/Parliament/KbCore/parliament/Exceptions.h
+++ b/Parliament/KbCore/parliament/Exceptions.h
@@ -23,20 +23,20 @@ using SysErrCode = uint32;
 using SysErrCode = int;
 #endif
 
-class Exception : public ::std::exception
+class PARLIAMENT_EXPORT Exception : public ::std::exception
 {
 public:
-	PARLIAMENT_EXPORT Exception(const char* pMsg) noexcept;
-	PARLIAMENT_EXPORT Exception(const ::std::string& msg) noexcept;
-	PARLIAMENT_EXPORT Exception(const ::boost::format& fmt);
-	PARLIAMENT_EXPORT Exception(const Exception& rhs) noexcept;
-	PARLIAMENT_EXPORT Exception& operator=(const Exception& rhs) noexcept;
-	PARLIAMENT_EXPORT ~Exception() override;
+	Exception(const char* pMsg) noexcept;
+	Exception(const ::std::string& msg) noexcept;
+	Exception(const ::boost::format& fmt);
+	Exception(const Exception& rhs) noexcept;
+	Exception& operator=(const Exception& rhs) noexcept;
+	~Exception() override;
 
 	const char* what() const noexcept override { return m_msg; }
 
-	PARLIAMENT_EXPORT static SysErrCode getSysErrCode() noexcept;
-	PARLIAMENT_EXPORT static ::std::string getSysErrMsg(SysErrCode errCode);
+	static SysErrCode getSysErrCode() noexcept;
+	static ::std::string getSysErrMsg(SysErrCode errCode);
 
 private:
 	inline void copyMsg(const char* pMsg) noexcept;
@@ -44,7 +44,7 @@ private:
 	char m_msg[384];
 };
 
-class UnicodeException : public Exception
+class PARLIAMENT_EXPORT UnicodeException : public Exception
 {
 public:
 	UnicodeException(const char* pMsg) noexcept : Exception(pMsg) {}
@@ -52,7 +52,7 @@ public:
 	UnicodeException(const ::boost::format& fmt) : Exception(fmt) {}
 };
 
-class UnimplementedException : public Exception
+class PARLIAMENT_EXPORT UnimplementedException : public Exception
 {
 public:
 	UnimplementedException(const char* pMsg) noexcept : Exception(pMsg) {}
@@ -60,7 +60,7 @@ public:
 	UnimplementedException(const ::boost::format& fmt) : Exception(fmt) {}
 };
 
-class UsageException : public Exception
+class PARLIAMENT_EXPORT UsageException : public Exception
 {
 public:
 	UsageException(const char* pMsg) noexcept : Exception(pMsg) {}

--- a/Parliament/KbCore/parliament/Exceptions.h
+++ b/Parliament/KbCore/parliament/Exceptions.h
@@ -15,6 +15,15 @@
 
 #include <boost/format.hpp>
 
+// UNIX/Linux compilers require that the exception classes themselves be exported so
+// that their RTTI is exported, but this upsets MSVC because the base class
+// (std::exception) is not exported.
+#if defined(PARLIAMENT_WINDOWS)
+#define NON_WINDOWS_PARLIAMENT_EXPORT
+#else
+#define NON_WINDOWS_PARLIAMENT_EXPORT PARLIAMENT_EXPORT
+#endif
+
 PARLIAMENT_NAMESPACE_BEGIN
 
 #if defined(PARLIAMENT_WINDOWS)
@@ -23,20 +32,20 @@ using SysErrCode = uint32;
 using SysErrCode = int;
 #endif
 
-class PARLIAMENT_EXPORT Exception : public ::std::exception
+class NON_WINDOWS_PARLIAMENT_EXPORT Exception : public ::std::exception
 {
 public:
-	Exception(const char* pMsg) noexcept;
-	Exception(const ::std::string& msg) noexcept;
-	Exception(const ::boost::format& fmt);
-	Exception(const Exception& rhs) noexcept;
-	Exception& operator=(const Exception& rhs) noexcept;
-	~Exception() override;
+	PARLIAMENT_EXPORT Exception(const char* pMsg) noexcept;
+	PARLIAMENT_EXPORT Exception(const ::std::string& msg) noexcept;
+	PARLIAMENT_EXPORT Exception(const ::boost::format& fmt);
+	PARLIAMENT_EXPORT Exception(const Exception& rhs) noexcept;
+	PARLIAMENT_EXPORT Exception& operator=(const Exception& rhs) noexcept;
+	PARLIAMENT_EXPORT ~Exception() override;
 
 	const char* what() const noexcept override { return m_msg; }
 
-	static SysErrCode getSysErrCode() noexcept;
-	static ::std::string getSysErrMsg(SysErrCode errCode);
+	PARLIAMENT_EXPORT static SysErrCode getSysErrCode() noexcept;
+	PARLIAMENT_EXPORT static ::std::string getSysErrMsg(SysErrCode errCode);
 
 private:
 	inline void copyMsg(const char* pMsg) noexcept;
@@ -44,7 +53,7 @@ private:
 	char m_msg[384];
 };
 
-class PARLIAMENT_EXPORT UnicodeException : public Exception
+class NON_WINDOWS_PARLIAMENT_EXPORT UnicodeException : public Exception
 {
 public:
 	UnicodeException(const char* pMsg) noexcept : Exception(pMsg) {}
@@ -52,7 +61,7 @@ public:
 	UnicodeException(const ::boost::format& fmt) : Exception(fmt) {}
 };
 
-class PARLIAMENT_EXPORT UnimplementedException : public Exception
+class NON_WINDOWS_PARLIAMENT_EXPORT UnimplementedException : public Exception
 {
 public:
 	UnimplementedException(const char* pMsg) noexcept : Exception(pMsg) {}
@@ -60,7 +69,7 @@ public:
 	UnimplementedException(const ::boost::format& fmt) : Exception(fmt) {}
 };
 
-class PARLIAMENT_EXPORT UsageException : public Exception
+class NON_WINDOWS_PARLIAMENT_EXPORT UsageException : public Exception
 {
 public:
 	UsageException(const char* pMsg) noexcept : Exception(pMsg) {}

--- a/Parliament/KbCore/parliament/Platform.h
+++ b/Parliament/KbCore/parliament/Platform.h
@@ -110,8 +110,9 @@
 #		define PARLIAMENT_EXPORT __declspec(dllimport)
 #		define PARLIAMENT_EXPORT_TEMPLATE_INST extern template class PARLIAMENT_EXPORT
 #	endif
-//#elif defined(PARLIAMENT_MACOS) && !defined(PARLIAMENT_SUPPRESS_EXPORTS)
-//#	define PARLIAMENT_EXPORT __attribute__((visibility("default")))
+#elif (defined(PARLIAMENT_MACOS) || defined(PARLIAMENT_LINUX)) && !defined(PARLIAMENT_SUPPRESS_EXPORTS)
+#	define PARLIAMENT_EXPORT __attribute__((visibility("default")))
+#	define PARLIAMENT_EXPORT_TEMPLATE_INST
 #else
 #	define PARLIAMENT_EXPORT
 #	define PARLIAMENT_EXPORT_TEMPLATE_INST

--- a/Parliament/Test/ConfigTest.cpp
+++ b/Parliament/Test/ConfigTest.cpp
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(testConfigDefaultCtor)
 	BOOST_CHECK_EQUAL(false, c.inferRdfsResource());
 	BOOST_CHECK_EQUAL(false, c.inferOwlThing());
 
-	BOOST_CHECK_EQUAL(5, c.timeoutDuration());
+	BOOST_CHECK_EQUAL(5u, c.timeoutDuration());
 	BOOST_CHECK_EQUAL(string("MINUTES"), c.timeoutUnit());
 }
 
@@ -439,7 +439,7 @@ BOOST_AUTO_TEST_CASE(testConfigReadFromFile)
 		BOOST_CHECK_EQUAL(true, c.inferRdfsResource());
 		BOOST_CHECK_EQUAL(false, c.inferOwlThing());
 
-		BOOST_CHECK_EQUAL(200, c.timeoutDuration());
+		BOOST_CHECK_EQUAL(200u, c.timeoutDuration());
 		BOOST_CHECK_EQUAL(string("MILLISECONDS"), c.timeoutUnit());
 	}
 

--- a/Parliament/Test/Jamfile
+++ b/Parliament/Test/Jamfile
@@ -35,6 +35,7 @@ run [ glob *.cpp : UnicodeTestCaseGen.cpp ]
 		<include>$(KbCoreDir)
 		<define>PARLIAMENT_SUPPRESS_EXPORTS
 		<define>PARLIAMENT_UNIT_TEST
+		<visibility>hidden
 		<threading>multi
 		<dependency>ParliamentConfig.txt
 		<dependency>$(TestDir)/ParliamentConfig.txt
@@ -64,6 +65,7 @@ unit-test ParliamentTestOld
 		<include>$(KbCoreDir)
 		<define>PARLIAMENT_SUPPRESS_EXPORTS
 		<define>PARLIAMENT_UNIT_TEST
+		<visibility>hidden
 		<threading>multi
 		<dependency>ParliamentConfig.txt
 		<dependency>$(TestDir)/ParliamentConfig.txt
@@ -87,6 +89,7 @@ make $(TestDir)/ParliamentConfig.txt : $(KbCoreDir)/ParliamentConfig.txt : @comm
 exe UnicodeTestCaseGen
 	:	UnicodeTestCaseGen.cpp
 	:	<include>.
+		<visibility>hidden
 		<threading>multi
 		<os>NT:<build>yes
 	:	<build>no

--- a/doc/Linux/site-config.jam
+++ b/doc/Linux/site-config.jam
@@ -59,7 +59,7 @@ alias BoostAtomic
 		$(Boost32StDbgLibPfx)atomic$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)atomic$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostChrono
@@ -73,7 +73,7 @@ alias BoostChrono
 		$(Boost32StDbgLibPfx)chrono$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)chrono$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostDateTime
@@ -87,7 +87,7 @@ alias BoostDateTime
 		$(Boost32StDbgLibPfx)date_time$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)date_time$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostFileSystem
@@ -101,7 +101,7 @@ alias BoostFileSystem
 		$(Boost32StDbgLibPfx)filesystem$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)filesystem$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostLog
@@ -115,7 +115,7 @@ alias BoostLog
 		$(Boost32StDbgLibPfx)log$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)log$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 		<link>shared:<define>BOOST_LOG_DYN_LINK
 		<define>BOOST_LOG_NO_SHORTHAND_NAMES
 	;
@@ -131,7 +131,7 @@ alias BoostLogSetup
 		$(Boost32StDbgLibPfx)log_setup$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)log_setup$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 		<link>shared:<define>BOOST_LOG_DYN_LINK
 		<define>BOOST_LOG_NO_SHORTHAND_NAMES
 	;
@@ -147,7 +147,7 @@ alias BoostRegex
 		$(Boost32StDbgLibPfx)regex$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)regex$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostSystem
@@ -161,7 +161,7 @@ alias BoostSystem
 		$(Boost32StDbgLibPfx)system$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)system$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostThread
@@ -175,7 +175,7 @@ alias BoostThread
 		$(Boost32StDbgLibPfx)thread$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)thread$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostUnitTest
@@ -189,7 +189,7 @@ alias BoostUnitTest
 		$(Boost32StDbgLibPfx)unit_test_framework$(Boost32StDbgLibSfx)
 		$(Boost32StRlsLibPfx)unit_test_framework$(Boost32StRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 		<define>BOOST_TEST_ALTERNATIVE_INIT_API
 		<link>shared:<define>BOOST_TEST_DYN_LINK
 	;

--- a/doc/Linux/site-config.jam
+++ b/doc/Linux/site-config.jam
@@ -15,7 +15,7 @@ constant BoostVersionAbbrv : $(BoostVersionAbbrvAlternatives[1]) ;
 constant BdbVersion : [ os.environ BDB_VERSION ] ;
 constant LinuxDistro : [ os.environ LINUX_DISTRO ] ;
 
-constant COMPILER_ubuntu18 : gcc73 ;	# Ubuntu 18.04
+constant COMPILER_ubuntu18 : gcc7 ;		# Ubuntu 18.04
 constant COMPILER_ubuntu17 : gcc72 ;	# Ubuntu 17.04
 constant COMPILER_ubuntu16 : gcc54 ;	# Ubuntu 16.04
 constant COMPILER_centos   : gcc48 ;	# CentOS 7

--- a/doc/Linux/user-config.jam
+++ b/doc/Linux/user-config.jam
@@ -3,7 +3,7 @@ import os ;
 
 constant LinuxDistro : [ os.environ LINUX_DISTRO ] ;
 
-constant FLAGS_ubuntu18 : <cxxflags>"-std=c++17 -Wall" <linkflags>"-std=c++17" <visibility>hidden ;
+constant FLAGS_ubuntu18 : <cxxflags>"-std=c++17 -Wall" <linkflags>"-std=c++17" ;
 constant FLAGS_ubuntu17 : <cxxflags>"-std=c++14 -Wall" <linkflags>"-std=c++14" ;
 constant FLAGS_ubuntu16 : <cxxflags>"-std=c++14 -Wall" <linkflags>"-std=c++14" ;
 constant FLAGS_centos   : <cxxflags>"-std=c++11 -Wall" <linkflags>"-std=c++11" ;

--- a/doc/Linux/user-config.jam
+++ b/doc/Linux/user-config.jam
@@ -3,7 +3,7 @@ import os ;
 
 constant LinuxDistro : [ os.environ LINUX_DISTRO ] ;
 
-constant FLAGS_ubuntu18 : <cxxflags>"-std=c++17 -Wall" <linkflags>"-std=c++17" ;
+constant FLAGS_ubuntu18 : <cxxflags>"-std=c++17 -Wall" <linkflags>"-std=c++17" <visibility>hidden ;
 constant FLAGS_ubuntu17 : <cxxflags>"-std=c++14 -Wall" <linkflags>"-std=c++14" ;
 constant FLAGS_ubuntu16 : <cxxflags>"-std=c++14 -Wall" <linkflags>"-std=c++14" ;
 constant FLAGS_centos   : <cxxflags>"-std=c++11 -Wall" <linkflags>"-std=c++11" ;

--- a/doc/MacOS/site-config.jam
+++ b/doc/MacOS/site-config.jam
@@ -42,7 +42,7 @@ alias BoostAtomic
 		$(BoostStDbgLibPfx)atomic$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)atomic$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostChrono
@@ -52,7 +52,7 @@ alias BoostChrono
 		$(BoostStDbgLibPfx)chrono$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)chrono$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostDateTime
@@ -62,7 +62,7 @@ alias BoostDateTime
 		$(BoostStDbgLibPfx)date_time$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)date_time$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostFileSystem
@@ -72,7 +72,7 @@ alias BoostFileSystem
 		$(BoostStDbgLibPfx)filesystem$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)filesystem$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostLog
@@ -82,7 +82,7 @@ alias BoostLog
 		$(BoostStDbgLibPfx)log$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)log$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 		<link>shared:<define>BOOST_LOG_DYN_LINK
 		<define>BOOST_LOG_NO_SHORTHAND_NAMES
 	;
@@ -94,7 +94,7 @@ alias BoostLogSetup
 		$(BoostStDbgLibPfx)log_setup$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)log_setup$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 		<link>shared:<define>BOOST_LOG_DYN_LINK
 		<define>BOOST_LOG_NO_SHORTHAND_NAMES
 	;
@@ -106,7 +106,7 @@ alias BoostRegex
 		$(BoostStDbgLibPfx)regex$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)regex$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostSystem
@@ -116,7 +116,7 @@ alias BoostSystem
 		$(BoostStDbgLibPfx)system$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)system$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostThread
@@ -126,7 +126,7 @@ alias BoostThread
 		$(BoostStDbgLibPfx)thread$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)thread$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 	;
 
 alias BoostUnitTest
@@ -136,7 +136,7 @@ alias BoostUnitTest
 		$(BoostStDbgLibPfx)unit_test_framework$(BoostStDbgLibSfx)
 		$(BoostStRlsLibPfx)unit_test_framework$(BoostStRlsLibSfx)
 	:	# no default build
-	:	<include>$(BoostDir) <threading>multi
+	:	<include>$(BoostDir)
 		<define>BOOST_TEST_ALTERNATIVE_INIT_API
 		<link>shared:<define>BOOST_TEST_DYN_LINK
 	;

--- a/doc/MacOS/user-config.jam
+++ b/doc/MacOS/user-config.jam
@@ -6,7 +6,6 @@
 using clang
 	: # version
 	: # c++-compile-command
-	:	<visibility>hidden
-		<cxxflags>"-std=c++17 -Wall"
+	:	<cxxflags>"-std=c++17 -Wall"
 		<linkflags>"-std=c++17 -headerpad_max_install_names"
 	;

--- a/doc/MacOS/user-config.jam
+++ b/doc/MacOS/user-config.jam
@@ -6,6 +6,7 @@
 using clang
 	: # version
 	: # c++-compile-command
-	:	<cxxflags>"-std=c++17 -fvisibility=default -Wall"
-		<linkflags>"-std=c++17 -fvisibility=default -headerpad_max_install_names"
+	:	<visibility>hidden
+		<cxxflags>"-std=c++17 -Wall"
+		<linkflags>"-std=c++17 -headerpad_max_install_names"
 	;

--- a/doc/ReleaseNotes.txt
+++ b/doc/ReleaseNotes.txt
@@ -2,7 +2,7 @@ Version 2.7.12 (?, revision ?):
 
 * Moved to GitHub
 
-* Updated to Boost 1.68.0 and MSVC 14.1 (Visual Studio 2017, 15.8.8)
+* Updated to Boost 1.69.0 and MSVC 14.1 (Visual Studio 2017, 15.8.8)
 
 * Updated C++ code to use Boost.FileSystem and the Win32 wide character (UTF-16) API
 
@@ -29,6 +29,8 @@ Version 2.7.12 (?, revision ?):
 
 * Added two configuration properties to ParliamentConfig.txt to cause long-running
   queries to time out.
+
+* Fixed a few bugs in the temporal index implementation and unit tests.
 
 
 

--- a/doc/UserGuide/Building.tex
+++ b/doc/UserGuide/Building.tex
@@ -135,13 +135,13 @@ We emphasize libraries that work well with the C++ Standard Library. Boost libra
 We aim to establish ``existing practice'' and provide reference implementations so that Boost libraries are suitable for eventual standardization. Ten Boost libraries are already included in the \href{http://www.open-std.org/jtc1/sc22/wg21/}{C++ Standards Committee's} Library Technical Report (\href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1745.pdf}{TR1}) and in the new C++11 Standard.  C++11 also includes several more Boost libraries in addition to those from TR1.  More Boost libraries are proposed for \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1810.html}{TR2}.
 \end{quote}
 
-To get started, download the Boost source distribution (version 1.68.0 or later) from the Boost web site.  Unpack this to a handy location on your disk.  This location may be anywhere you like, but note that it is not temporary.  We will call this location \verb|BOOST_ROOT|, and you need to define an environment variable pointing there, such as
+To get started, download the Boost source distribution (version 1.69.0 or later) from the Boost web site.  Unpack this to a handy location on your disk.  This location may be anywhere you like, but note that it is not temporary.  We will call this location \verb|BOOST_ROOT|, and you need to define an environment variable pointing there, such as
 \begin{verbatim}
-export BOOST_ROOT=~/boost_1_68_0
+export BOOST_ROOT=~/boost_1_69_0
 \end{verbatim}
 or
 \begin{verbatim}
-set BOOST_ROOT=C:\boost_1_68_0
+set BOOST_ROOT=C:\boost_1_69_0
 \end{verbatim}
 From \acp{pmnt} point of view, there are two primary components contained within \verb|BOOST_ROOT|.  The first (and most obvious) is the boost libraries themselves.  Most of these are so-called ``header-only'' libraries, meaning that there is no pre-compiled library code or shared or dynamic library.  All of the code of such libraries is referenced via \verb|#include| directives and compiled along with the calling code.  Such libraries are extremely convenient, because they require virtually zero setup.  \ac{pmnt} uses several Boost libraries that are not header-only.  We will discuss how to build these libraries below.
 
@@ -216,7 +216,7 @@ Next we need to configure Boost.Build so that it can build \ac{pmnt}.  Start by 
 
 	\item\verb|BDB_HOME|: As described above in Section~\ref{sec:BuildingBerkeleyDB}.
 
-	\item\verb|BOOST_VERSION|: The version of Boost (currently 1\_68\_0).
+	\item\verb|BOOST_VERSION|: The version of Boost (currently 1\_69\_0).
 
 	\item\verb|BOOST_ROOT|: As described above in Section~\ref{sec:BuildingBoost}.
 


### PR DESCRIPTION
The basic update, plus fixes for a bunch of compiler and Boost.Build warnings.